### PR TITLE
Update Update-ProjectVersionNumber.ps1

### DIFF
--- a/VSTS/Update-ProjectVersionNumber.ps1
+++ b/VSTS/Update-ProjectVersionNumber.ps1
@@ -48,4 +48,4 @@ if ($projectDef.Url -like '*?*')
 }
 $putUrl = "$($projectDef.Url)$($separator)api-version=$apiVersion"
 Write-Verbose "Updating Project Build number with URL: $putUrl"
-Invoke-RestMethod -Method Put -Uri $putUrl -Headers $header -ContentType "application/json" -Body $projectDefJson | Out-Null
+Invoke-RestMethod -Method Put -Uri $putUrl -Headers $header -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($projectDefJson))  | Out-Null


### PR DESCRIPTION
According to https://stackoverflow.com/questions/50044942/issue-when-updating-build-definition-using-the-rest-api-of-vsts that can throw deserialization exception due to encoding mismatch